### PR TITLE
hard-source-webpack-pluginを無効化

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -58,7 +58,7 @@ const nuxtConfig: Configuration = {
   */
   build: {
     extractCSS: true,
-    hardSource: true,
+    hardSource: false,
 
     transpile: [
       'vee-validate/dist/rules',


### PR DESCRIPTION
ビルドでよくコケるので、`hard-source-webpack-plugin`を無効化して使用しないように