### PR TITLE
Renovate の設定を更新

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,13 @@
   "timezone": "Asia/Tokyo",
   "schedule": [
     "every weekend"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "Dockerfile"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,6 @@
     ],
     "timezone": "Asia/Tokyo",
     "schedule": [
-        "before 7am every weekday",
-        "after 7pm every weekday",
-        "before 7am every weekend",
-        "after 7pm every weekend"
+        "every weekend"
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
-    "extends": [
-        "config:base"
-    ],
-    "timezone": "Asia/Tokyo",
-    "schedule": [
-        "every weekend"
-    ]
+  "extends": [
+    "config:base"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": [
+    "every weekend"
+  ]
 }


### PR DESCRIPTION
## 概要

Renovate の設定を更新。

`schedule` の変更でパッケージ更新時間の統一と, `packageRules` で除外するファイルを設定

## 変更内容

- `schedule` を毎日7時,19時から, 週末に変更
- `Dockerfile` のアップデートを無効化

## 影響範囲

なし

## 動作要件

なし

## 補足

なし