### PR TITLE
Renovate の auto merge を patch update で有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,8 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "patch": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## 概要

Renovate の auto merge を patch update で有効化。

patch update で一々手動マージは中々面倒なので自動化

## 変更内容

- `renovate.json` ファイルに `patch` フィールドを追加

## 影響範囲

なし

## 動作要件

なし

## 補足

なし