### PR TITLE
Renovate の lockFileMaintenance を有効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
       "enabled": false
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 8am on the first day of the month"
+    ]
+  },
   "patch": {
     "automerge": true
   }


### PR DESCRIPTION
## 概要

Renovate の lockFileMaintenance を有効化。

#97 で入れ忘れ。

## 変更内容

`renovate.json` ファイルに `lockFileMaintenance` プロパティを追加。

## 影響範囲

なし

## 動作要件

なし

## 補足

なし