### PR TITLE
`@nuxtjs/eslint-module` をインストール

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,6 +51,8 @@ const nuxtConfig: Configuration = {
       typeCheck: true,
       ignoreNotFoundWarnings: true,
     }],
+
+    '@nuxtjs/eslint-module',
   ],
 
   /*

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,21 +64,12 @@ const nuxtConfig: Configuration = {
       'vee-validate/dist/rules',
     ],
 
-    extend (config, { isDev, isClient }): void {
+    extend (config): void {
       config.module.rules.push({
         test: /\.md$/,
         loader: 'raw-loader',
         exclude: /(node_modules)/,
       });
-
-      if (isDev && isClient) {
-        config.module.rules.push({
-          enforce: 'pre',
-          test: /\.(js|vue)$/,
-          loader: 'eslint-loader',
-          exclude: /(node_modules)/,
-        });
-      }
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@nuxt/types": "0.5.9",
     "@nuxt/typescript-build": "0.5.4",
+    "@nuxtjs/eslint-module": "^1.1.0",
     "@types/marked": "0.7.2",
     "@typescript-eslint/eslint-plugin": "2.13.0",
     "@typescript-eslint/parser": "2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,6 +1084,14 @@
     webpack-node-externals "^1.7.2"
     webpackbar "^4.0.0"
 
+"@nuxtjs/eslint-module@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-module/-/eslint-module-1.1.0.tgz#816f8d41c3883e8131ce5f863a0ca2f3fd7cbcbf"
+  integrity sha512-9np9tKQ30ULIfT7Zshhw9Gc8Xf437/X7jUGG2Wv4SwT26Miu0WE0q9FNXUt9gxaBIQuokKiWsoTT28rXUaxHjQ==
+  dependencies:
+    consola "^2.10.1"
+    eslint-loader "^3.0.0"
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"
@@ -3559,7 +3567,7 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-loader@3.0.3:
+eslint-loader@3.0.3, eslint-loader@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.3.tgz#e018e3d2722381d982b1201adb56819c73b480ca"
   integrity sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==


### PR DESCRIPTION
## 概要

`build.extend` で行っていた ESLint 関連の設定は `@nuxtjs/eslint-module` で同じことが出来るので, `@nuxtjs/eslint-module` を使うようにする

## 変更内容

- `@nuxtjs/eslint-module` をインストール
- `nuxt.config.ts` の `build.extend` から ESLint 周りの設定を削除

## 影響範囲

なし

## 動作要件

なし

## 補足

なし