### PR TITLE
Node.js のバージョンを v12.15.0 に更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [11.x, 12.x]
+        node-version: [12.15.0]
 
     steps:
       - uses: actions/checkout@v1

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   command = "yarn run generate"
 
 [build.environment]
-  NODE_VERSION = "12.13.1"
+  NODE_VERSION = "12.15.0"


### PR DESCRIPTION
## 概要

Docker, GitHub Actions, Netlify で使用する Node.js のバージョンを v12.15.0 に更新.

## 変更内容

GitHub Actions と Netlify の設定ファイルを更新.
`Dockerfile` は既に更新済みのため, そのまま.

## 影響範囲

なし

## 動作要件

なし

## 補足

なし