### PR TITLE
Renovate のプリセットを GitHub の hiroxto/renovate-config に変更.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,5 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "timezone": "Asia/Tokyo",
-  "npm": {
-    "enabled": true,
-    "schedule": [
-      "on saturday"
-    ],
-    "patch": {
-      "automerge": true
-    }
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "schedule": [
-      "before 10am on the 20th day of the month"
-    ]
-  },
-  "pin": {
-    "enabled": true,
-    "automerge": true,
-    "schedule": [
-      "every weekday",
-      "every weekend"
-    ]
-  }
+    "github>hiroxto/renovate-config"
+  ]
 }


### PR DESCRIPTION
## 概要

Renovate のプリセットを GitHub の hiroxto/renovate-config に変更.
個別で設定を持たずに, 一括して管理する.

## 変更内容

`renovate.json` の内容を `hiroxto/renovate-config` を extends するだけに変更.

## 影響範囲

更新される曜日が, 毎週土曜から月曜に変更.
またロックファイルのメンテナンスは毎週金曜に.

## 動作要件

なし

## 補足

なし